### PR TITLE
Fix img tag attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const compile = marksy({
   em ({children}) {},
   br () {},
   del ({children}) {},
-  img ({src, alt}) {},
+  img ({src, alt, title}) {},
   code ({language, code}) {},
   codespan ({children}) {}
 })

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ export function marksy (options = {}) {
 
   renderer.image = function (href, title, text) {
     var id = inlineIds++;
-    inlines[id] = React.createElement(options.img || 'img', {src: href, alt: title, key: keys++});
+    inlines[id] = React.createElement(options.img || 'img', {src: href, alt: text, title: title, key: keys++});
     return '{{' + id + '}}';
   };
 


### PR DESCRIPTION
Hi @christianalfoni , 

I noticed a slight discrepancy between the properties returned by `marked` for `img` tags and the ones being used in this library. This was causing the `alt` attribute to always be null. Using the value of the `text` parameter for `alt` instead of `title` fixed the issue. I also added `title` as a third attribute and updated the README to reflect this change. 

Thanks!
