### PR TITLE
Add babelrc to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src
 app
 webpack.config.js
 build
+.babelrc


### PR DESCRIPTION
Prevents issue like:

>  Error: Couldn't find preset “es2015” relative to directory node_modules/marksy