### PR TITLE
Add babel-cli so build doesn't depend on global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/cerebral/marksy",
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-jest": "^19.0.0",
     "babel-loader": "^7.0.0",


### PR DESCRIPTION
`npm run build` uses the `babel` bin, but this fails if `babel` hasn't been installed globally.

I've added `babel-cli` as a dev dependency so that it will be guaranteed to work.