### PR TITLE
Add babel-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/cerebral/marksy",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.24.1",
     "babel-jest": "^19.0.0",
     "babel-loader": "^7.0.0",


### PR DESCRIPTION
issue: your `build` script implies the presence of `babel-cli` but if fails if you don't have it globally