### PR TITLE
Make `elements.code` and `elements.codespan` options work as documented

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,9 +3,7 @@
 exports[`should allow injecting context to components 1`] = `
 <div>
   <div>
-    <div>
-      bar
-    </div>
+    bar
   </div>
 </div>
 `;
@@ -61,9 +59,7 @@ exports[`should be able to compile codespans 1`] = `
 exports[`should be able to compile components 1`] = `
 <div>
   <div>
-    <div>
-      mip
-    </div>
+    mip
   </div>
 </div>
 `;
@@ -71,9 +67,7 @@ exports[`should be able to compile components 1`] = `
 exports[`should be able to compile components using marksy language 1`] = `
 <div>
   <div>
-    <div>
-      mip
-    </div>
+    mip
   </div>
 </div>
 `;
@@ -118,9 +112,7 @@ exports[`should be able to compile html 1`] = `
 exports[`should be able to compile html as components 1`] = `
 <div>
   <div>
-    <div>
-      hello
-    </div>
+    hello
   </div>
 </div>
 `;
@@ -326,14 +318,12 @@ exports[`should be able to compile text 1`] = `
 
 exports[`should be able to inline components 1`] = `
 <div>
-  <div>
-    <p>
-      Hello there 
-      <div>
-        Wuuut
-      </div>
-    </p>
-  </div>
+  <p>
+    Hello there 
+    <div>
+      Wuuut
+    </div>
+  </p>
 </div>
 `;
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -16,7 +16,38 @@ exports[`should allow injecting context to elements 1`] = `
 </div>
 `;
 
-exports[`should allow overriding code element with components version 1`] = `
+exports[`should allow overriding block code element 1`] = `
+<div>
+  <div>
+    js
+    : 
+    code
+  </div>
+</div>
+`;
+
+exports[`should allow overriding block code element with components version 1`] = `
+<div>
+  <div>
+    js
+    : 
+    code
+  </div>
+</div>
+`;
+
+exports[`should allow overriding inline code element 1`] = `
+<div>
+  <p>
+    Hello 
+    <div>
+      code
+    </div>
+  </p>
+</div>
+`;
+
+exports[`should allow overriding inline code element with components version 1`] = `
 <div>
   <p>
     Hello 

--- a/src/components.js
+++ b/src/components.js
@@ -5,13 +5,6 @@ import {transform} from 'babel-standalone';
 export function marksy (options = {}) {
   options.components = options.components || {};
 
-  function CodeComponent (props) {
-    return options.createElement('pre', null, options.createElement('code', {
-      className: `language-${props.language}`,
-      dangerouslySetInnerHTML: {__html: options.highlight ? options.highlight(props.language, props.code) : props.code}
-    }))
-  }
-
   const tracker = {
     tree: null,
     elements: null,

--- a/src/components.js
+++ b/src/components.js
@@ -1,4 +1,4 @@
-import createRenderer from './createRenderer';
+import createRenderer, {codeRenderer} from './createRenderer';
 import marked from 'marked';
 import {transform} from 'babel-standalone';
 
@@ -41,13 +41,7 @@ export function marksy (options = {}) {
       if (language === 'marksy') {
         return renderer.html(code)
       } else {
-        const elementId = tracker.nextElementId++;
-
-        tracker.elements[elementId] = options.createElement((options.elements && options.elements.code) || CodeComponent, {key: elementId, code, language});
-
-        tracker.tree.push(tracker.elements[elementId]);
-
-        return `{{${elementId}}}`;
+        return codeRenderer(tracker, options)(code, language);
       }
     }
   })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -380,16 +380,71 @@ it('should be able to inline components', () => {
   expect(tree).toMatchSnapshot();
 });
 
-it('should allow overriding code element with components version', () => {
-  const compile = marksyComponents({
+it('should allow overriding inline code element', () => {
+  const compile = marksy({
     createElement,
     elements: {
-      code() {
-        return <div>code</div>
+      codespan({children}) {
+        return <div>{children}</div>
       }
     }
   });
   const compiled = compile('Hello `code`');
+
+  const tree = renderer.create(
+    <TestComponent>{compiled.tree}</TestComponent>
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('should allow overriding inline code element with components version', () => {
+  const compile = marksyComponents({
+    createElement,
+    elements: {
+      codespan({children}) {
+        return <div>{children}</div>
+      }
+    }
+  });
+  const compiled = compile('Hello `code`');
+
+  const tree = renderer.create(
+    <TestComponent>{compiled.tree}</TestComponent>
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('should allow overriding block code element', () => {
+  const compile = marksy({
+    createElement,
+    elements: {
+      code({language, code}) {
+        console.log(language, code)
+        return <div>{language}: {code}</div>
+      }
+    }
+  });
+  const compiled = compile('```js\ncode\n```');
+
+  const tree = renderer.create(
+    <TestComponent>{compiled.tree}</TestComponent>
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+it('should allow overriding block code element with components version', () => {
+  const compile = marksyComponents({
+    createElement,
+    elements: {
+      code({language, code}) {
+        return <div>{language}: {code}</div>
+      }
+    }
+  });
+  const compiled = compile('```js\ncode\n```');
 
   const tree = renderer.create(
     <TestComponent>{compiled.tree}</TestComponent>


### PR DESCRIPTION
Issue: https://github.com/cerebral/marksy/issues/38

Current behaviour:
— block code rendering can be overriden only in "components" mode
— inline code is rendered by `elements.code` not `element.codespan`

Desired (and documented) behaviour:
— block code rendering can be overriden with `elements.code({language, code})`
— inline code rendering can be overriden with `elements.codespan({children})`
