### PR TITLE
Test case showing `code` element is blocks & spans

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -29,6 +29,14 @@ exports[`should allow overriding code element with components version 1`] = `
 </div>
 `;
 
+exports[`should allow overriding codeblock element with components version 1`] = `
+<div>
+  <div>
+    code
+  </div>
+</div>
+`;
+
 exports[`should be able to combine in compilation 1`] = `
 <div>
   <h1

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -398,6 +398,24 @@ it('should allow overriding code element with components version', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('should allow overriding codeblock element with components version', () => {
+    const compile = marksyComponents({
+        createElement,
+        elements: {
+            code() {
+                return <div>code</div>
+            }
+        }
+    });
+    const compiled = compile('```js\nconst foo = "bar"\n```');
+
+    const tree = renderer.create(
+        <TestComponent>{compiled.tree}</TestComponent>
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+});
+
 it('should highlight code with highlight.js', () => {
   const compile = marksy({
     createElement,


### PR DESCRIPTION
The docs provide the list of elements and the parameters passed to the functions that generate them, including a `code` & `codespan` tag. It appears, based on my digging into [this issue in spectacle](https://github.com/FormidableLabs/spectacle/pull/427) that `code` is actually used for both `code` and `codespan` elements. My understanding (and the understanding of the Spectacle guys) appear to be that `code` is for code blocks, wrapped in a `pre`, whereas `codespan` is for inline code. However, we have this test:

```js
it('should allow overriding code element with components version', () => {
  const compile = marksyComponents({
    createElement,
    elements: {
      code() {
        return <div>code</div>
      }
    }
  });
  const compiled = compile('Hello `code`');

  const tree = renderer.create(
    <TestComponent>{compiled.tree}</TestComponent>
  ).toJSON();

  expect(tree).toMatchSnapshot();
});
```

That indicates that the `code` work on inline blocks. However, the test I just added indicates that `code` is also used for code blocks as well. So there's currently no hook for the `codespan` element currently indicated in the docs.

I'm opening up the test case to demonstrate the issue and get some guidance on how to fix it. Thoughts?